### PR TITLE
Add config.json

### DIFF
--- a/python/config.json
+++ b/python/config.json
@@ -1,0 +1,5 @@
+{
+    "SECRET_KEY": "any-random-string",
+    "NYLAS_OAUTH_CLIENT_ID": "your-client-id",
+    "NYLAS_OAUTH_CLIENT_SECRET": "your-client-secret"
+}


### PR DESCRIPTION
Setup instructions for python example call for replacing values in config.json but file is missing.