### PR TITLE
docs: archived notice + redirect to v3 Scheduler

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,22 @@
+<div align="center">
+  <a href="https://www.nylas.com/">
+    <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
+  </a>
 
+  <h1>Nylas Scheduler Examples</h1>
+</div>
 
-### Nylas Scheduler Sample Code 🎯
+<br />
 
-- **[Quick Start Simple Example](https://github.com/nylas/scheduler-examples/tree/master/simple-example.html)**: A simple html file that is the quickest way to
-  test out the schedule editor and create your own scheduling page. Showcases the instant integration type. You'll need to get your own access token through the [Nylas Dashboard](https://dashboard.nylas.com) to run this example.
+> ## ⚠️ This repository is archived and no longer maintained
+>
+> These examples target an earlier version of the Nylas Scheduler and reference the legacy dashboard. They are preserved for historical reference and no longer reflect the current v3 Scheduler.
 
-- **[NodeJS Hosted Auth + Scheduling](https://github.com/nylas/scheduler-examples/tree/master/node)**: A NodeJS / TypeScript example that showcases both instant and smart integration types. Also demonstrates how to theme the schedule editor to match your application.
+## Current Scheduler resources
 
-- **[Python Hosted Auth + Scheduling](https://github.com/nylas/scheduler-examples/tree/master/python)**: A Python example that showcases both instant and smart integration types. Also demonstrates how to theme the schedule editor to match your application.
+Nylas Scheduler v3 ships embeddable UI components and booking APIs. Start here:
+
+- 📅 [Scheduler documentation](https://developer.nylas.com/docs/v3/scheduler/)
+- ⚡ [Scheduler quickstart](https://developer.nylas.com/docs/v3/getting-started/scheduler/)
+- 💡 [Current sample apps](https://github.com/orgs/nylas-samples/repositories)
+- 🚀 [Sign up for free](https://dashboard-v3.nylas.com/register)

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,19 @@
+> [!CAUTION]
+> 🛑 **This repository is archived and no longer maintained.**
+>
+> These examples target an earlier version of the Nylas Scheduler and reference the legacy dashboard; they no longer reflect the current v3 Scheduler. Do not use them for new projects — see current Nylas resources below.
+
 <div align="center">
   <a href="https://www.nylas.com/">
     <img width="100%" alt="Nylas" src="https://github.com/user-attachments/assets/137517ae-244d-47a5-8ca7-b12984971fc4" />
   </a>
 
   <h1>Nylas Scheduler Examples</h1>
+
+  <p><img src="https://img.shields.io/badge/Status-Archived-critical?style=for-the-badge" alt="Status: Archived" /></p>
 </div>
 
 <br />
-
-> ## ⚠️ This repository is archived and no longer maintained
->
-> These examples target an earlier version of the Nylas Scheduler and reference the legacy dashboard. They are preserved for historical reference and no longer reflect the current v3 Scheduler.
 
 ## Current Scheduler resources
 


### PR DESCRIPTION
Replaces the README with a concise archived notice that redirects visitors to current Nylas resources. Intended as the 'merge, then archive' step. All links verified (200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)